### PR TITLE
Adds SerializeMixin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script:
   - python examples/eagerload.py
   - python examples/repr.py
   - python examples/smartquery.py
+  - python examples/serialize.py
 after_success:
   - codeclimate-test-reporter

--- a/examples/serialize.py
+++ b/examples/serialize.py
@@ -1,0 +1,62 @@
+from __future__ import print_function
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from sqlalchemy_mixins import SerializeMixin
+
+Base = declarative_base()
+engine = sa.create_engine('sqlite:///:memory:')
+session = scoped_session(sessionmaker(bind=engine))
+
+
+class BaseModel(Base, SerializeMixin):
+    __abstract__ = True
+    pass
+
+
+class User(BaseModel):
+    __tablename__ = 'user'
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+    posts = sa.orm.relationship('Post', backref='user')
+
+
+class Post(BaseModel):
+    __tablename__ = 'post'
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    body = sa.Column(sa.String)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'))
+
+
+Base.metadata.create_all(engine)
+
+bob = User(name='Bob')
+session.add(bob)
+session.flush()
+
+post1 = Post(body='Post 1', user=bob)
+session.add(post1)
+session.flush()
+
+post2 = Post(body='Post 2', user=bob)
+session.add(post2)
+session.flush()
+
+# {'id': 1, 'name': 'Bob'}
+print(bob.to_dict())
+
+# {'id': 1,
+# 'name': 'Bob',
+# 'posts': [{'body': 'Post 1', 'id': 1, 'user_id': 1},
+#           {'body': 'Post 2', 'id': 2, 'user_id': 1}]}
+print(bob.to_dict(nested=True))
+
+# {'id': 1, 'body': 'Post 1', 'user_id': 1}
+print(post1.to_dict())
+
+# {'id': 2, 'body': 'Post 2', 'user_id': 1, 'user': {'id': 1, 'name': 'Bob'}}
+print(post2.to_dict(nested=True))

--- a/sqlalchemy_mixins/__init__.py
+++ b/sqlalchemy_mixins/__init__.py
@@ -7,6 +7,7 @@ from .activerecord import ActiveRecordMixin, ModelNotFoundError
 from .smartquery import SmartQueryMixin, smart_query
 from .eagerload import EagerLoadMixin, JOINED, SUBQUERY
 from .repr import ReprMixin
+from .serialize import SerializeMixin
 
 
 # all features combined to one mixin

--- a/sqlalchemy_mixins/serialize.py
+++ b/sqlalchemy_mixins/serialize.py
@@ -1,0 +1,27 @@
+from collections import Iterable
+
+
+class SerializeMixin:
+    """Mixin to make model serializable."""
+
+    def to_dict(self, nested=False):
+        """Return dict object with model's data.
+
+        :param nested: flag to return nested relationships' data if true
+        :type: bool
+        :return: dict
+        """
+        result = dict()
+        for key in self.__mapper__.c.keys():
+            result[key] = getattr(self, key)
+
+        if nested:
+            for key in self.__mapper__.relationships.keys():
+                obj = getattr(self, key)
+
+                if isinstance(obj, SerializeMixin):
+                    result[key] = obj.to_dict()
+                elif isinstance(obj, Iterable):
+                    result[key] = [o.to_dict() for o in obj]
+
+        return result

--- a/sqlalchemy_mixins/tests/test_serialize.py
+++ b/sqlalchemy_mixins/tests/test_serialize.py
@@ -1,0 +1,140 @@
+import unittest
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
+
+from sqlalchemy_mixins import SerializeMixin
+
+Base = declarative_base()
+
+
+class BaseModel(Base, SerializeMixin):
+    __abstract__ = True
+    pass
+
+
+class User(BaseModel):
+    __tablename__ = 'user'
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+    posts = sa.orm.relationship('Post')
+
+
+class Post(BaseModel):
+    __tablename__ = 'post'
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    body = sa.Column(sa.String)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'))
+    archived = sa.Column(sa.Boolean, default=False)
+
+    user = sa.orm.relationship('User')
+    comments = sa.orm.relationship('Comment')
+
+
+class Comment(BaseModel):
+    __tablename__ = 'comment'
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    body = sa.Column(sa.String)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('user.id'))
+    post_id = sa.Column(sa.Integer, sa.ForeignKey('post.id'))
+    rating = sa.Column(sa.Integer)
+
+    user = sa.orm.relationship('User')
+    post = sa.orm.relationship('Post')
+
+
+class TestSerialize(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine('sqlite:///:memory:', echo=False)
+
+    def setUp(self):
+        self.session = Session(self.engine)
+        Base.metadata.create_all(self.engine)
+
+        user_1 = User(name='Bill u1', id=1)
+        self.session.add(user_1)
+        self.session.commit()
+
+        user_2 = User(name='Alex u2', id=2)
+        self.session.add(user_2)
+        self.session.commit()
+
+        self.session.commit()
+
+        post_11 = Post(
+            id=11,
+            body='Post 11 body.',
+            archived=True
+        )
+        post_11.user = user_1
+        self.session.add(post_11)
+        self.session.commit()
+
+        comment_11 = Comment(
+            id=11,
+            body='Comment 11 body',
+            user=user_1,
+            post=post_11,
+            rating=1
+        )
+        self.session.add(comment_11)
+        self.session.commit()
+
+    def tearDown(self):
+        Base.metadata.drop_all(self.engine)
+
+    def test_serialize_single(self):
+        result = self.session.query(User).first().to_dict()
+        expected = {
+            'id': 1,
+            'name': 'Bill u1'
+        }
+        self.assertDictEqual(result, expected)
+
+    def test_serialize_list(self):
+        result = [user.to_dict() for user in self.session.query(User).all()]
+        expected = [
+            {
+                'id': 1,
+                'name': 'Bill u1'
+            },
+            {
+                'id': 2,
+                'name': 'Alex u2'
+            },
+        ]
+
+        self.assertListEqual(expected, result)
+
+    def test_serialize_nested(self):
+        result = self.session.query(Post).first().to_dict(nested=True)
+        expected = {
+            'id': 11,
+            'body': 'Post 11 body.',
+            'archived': True,
+            'user_id': 1,
+            'user': {
+                'id': 1,
+                'name': 'Bill u1'
+            },
+            'comments': [
+                {
+                    'id': 11,
+                    'body': 'Comment 11 body',
+                    'user_id': 1,
+                    'post_id': 11,
+                    'rating': 1,
+                }
+            ]
+        }
+        self.assertDictEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request implements SerializeMixin with to_dict() method (following #2)
I created tests and examples.

I took liberty to add a param nest to `to_dict(nested=False)` method, as I wrote in the docstring, it's a:
> flag to return nested relationships' data if true

Note this behavior returns only one depth of nested relationships.