### PR TITLE
Adds TimestampMixin 

### DIFF
--- a/examples/timestamp.py
+++ b/examples/timestamp.py
@@ -1,0 +1,53 @@
+from __future__ import print_function
+
+import time
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from sqlalchemy_mixins import TimestampsMixin
+
+Base = declarative_base()
+engine = sa.create_engine("sqlite:///:memory:")
+session = scoped_session(sessionmaker(bind=engine))
+
+
+class BaseModel(Base, TimestampsMixin):
+    __abstract__ = True
+    pass
+
+
+class User(BaseModel):
+    """User Model to example."""
+
+    __tablename__ = "users"
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+
+
+Base.metadata.create_all(engine)
+
+
+print("Current time:   ", datetime.utcnow())
+# Current time:    2019-03-04 03:53:53.605602
+
+bob = User(name="Bob")
+session.add(bob)
+session.flush()
+
+print("Created Bob:    ", bob.created_at)
+# Created Bob:     2019-03-04 03:53:53.606765
+
+print("Pre-update Bob: ", bob.updated_at)
+# Pre-update Bob:  2019-03-04 03:53:53.606769
+
+time.sleep(5)
+
+bob.name = "Robert"
+session.commit()
+
+print("Updated Bob:    ", bob.updated_at)
+# Updated Bob:     2019-03-04 03:53:58.613044

--- a/sqlalchemy_mixins/__init__.py
+++ b/sqlalchemy_mixins/__init__.py
@@ -8,6 +8,7 @@ from .smartquery import SmartQueryMixin, smart_query
 from .eagerload import EagerLoadMixin, JOINED, SUBQUERY
 from .repr import ReprMixin
 from .serialize import SerializeMixin
+from .timestamp import TimestampMixin
 
 
 # all features combined to one mixin

--- a/sqlalchemy_mixins/__init__.py
+++ b/sqlalchemy_mixins/__init__.py
@@ -8,7 +8,7 @@ from .smartquery import SmartQueryMixin, smart_query
 from .eagerload import EagerLoadMixin, JOINED, SUBQUERY
 from .repr import ReprMixin
 from .serialize import SerializeMixin
-from .timestamp import TimestampMixin
+from .timestamp import TimestampsMixin
 
 
 # all features combined to one mixin

--- a/sqlalchemy_mixins/tests/test_timestamp.py
+++ b/sqlalchemy_mixins/tests/test_timestamp.py
@@ -26,13 +26,6 @@ class User(BaseModel):
     __tablename__ = 'user'
 
 
-class UserCustomDatimeCallback(BaseModel):
-    """User model with custom `__datetime_callback__`."""
-
-    __tablename__ = 'user_custom_datetime_callback'
-    __datetime_callback__ = datetime.now
-
-
 class TestTimestamp(unittest.TestCase):
     """Test case for Timestamp mixin."""
 
@@ -46,10 +39,6 @@ class TestTimestamp(unittest.TestCase):
 
         user_1 = User(name='User')
         self.session.add(user_1)
-        self.session.commit()
-
-        user_2 = UserCustomDatimeCallback(name='Custom Datetime callback')
-        self.session.add(user_2)
         self.session.commit()
 
     def tearDown(self):
@@ -87,16 +76,6 @@ class TestTimestamp(unittest.TestCase):
         dt_2 = user.updated_at
 
         self.assertLess(dt_1, dt_2, 'dt_1 should be older than dt_2')
-
-    def test_datetime_callback_could_be_customized(self):
-        """Test whether __datetime_callback__ is customized."""
-        expected = 'now'
-        result = UserCustomDatimeCallback.__datetime_callback__.__name__
-
-        self.assertNotEqual(TimestampMixin.__datetime_callback__.__name__,
-                            result)
-        self.assertEqual(expected, result,
-                         '__datetime_callback__ was\'t custom')
 
 
 if __name__ == '__main__':

--- a/sqlalchemy_mixins/tests/test_timestamp.py
+++ b/sqlalchemy_mixins/tests/test_timestamp.py
@@ -6,12 +6,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session
 
-from sqlalchemy_mixins import TimestampMixin
+from sqlalchemy_mixins import TimestampsMixin
 
 Base = declarative_base()
 
 
-class BaseModel(Base, TimestampMixin):
+class BaseModel(Base, TimestampsMixin):
     """Model to use as base."""
 
     __abstract__ = True
@@ -26,7 +26,7 @@ class User(BaseModel):
     __tablename__ = 'user'
 
 
-class TestTimestamp(unittest.TestCase):
+class TestTimestamps(unittest.TestCase):
     """Test case for Timestamp mixin."""
 
     @classmethod
@@ -45,14 +45,14 @@ class TestTimestamp(unittest.TestCase):
         Base.metadata.drop_all(self.engine)
 
     def test_timestamp_must_be_abstract(self):
-        """Test whether TimestampMixin is abstract."""
-        self.assertTrue(hasattr(TimestampMixin, '__abstract__'),
-                        'TimestampMixin must have attribute __abstract__')
-        self.assertTrue(TimestampMixin.__abstract__,
+        """Test whether TimestampsMixin is abstract."""
+        self.assertTrue(hasattr(TimestampsMixin, '__abstract__'),
+                        'TimestampsMixin must have attribute __abstract__')
+        self.assertTrue(TimestampsMixin.__abstract__,
                         '__abstract__ must be True')
 
     def test_timestamp_has_datetime_columns(self):
-        """Test whether TimestampMixin has attrs created_at and updated_at."""
+        """Test whether TimestampsMixin has attrs created_at and updated_at."""
         user = self.session.query(User).first()
 
         self.assertTrue(hasattr(User, 'created_at'),

--- a/sqlalchemy_mixins/tests/test_timestamp.py
+++ b/sqlalchemy_mixins/tests/test_timestamp.py
@@ -1,0 +1,103 @@
+import unittest
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
+
+from sqlalchemy_mixins import TimestampMixin
+
+Base = declarative_base()
+
+
+class BaseModel(Base, TimestampMixin):
+    """Model to use as base."""
+
+    __abstract__ = True
+
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+
+
+class User(BaseModel):
+    """User model exemple."""
+
+    __tablename__ = 'user'
+
+
+class UserCustomDatimeCallback(BaseModel):
+    """User model with custom `__datetime_callback__`."""
+
+    __tablename__ = 'user_custom_datetime_callback'
+    __datetime_callback__ = datetime.now
+
+
+class TestTimestamp(unittest.TestCase):
+    """Test case for Timestamp mixin."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine('sqlite:///:memory:', echo=False)
+
+    def setUp(self):
+        self.session = Session(self.engine)
+        Base.metadata.create_all(self.engine)
+
+        user_1 = User(name='User')
+        self.session.add(user_1)
+        self.session.commit()
+
+        user_2 = UserCustomDatimeCallback(name='Custom Datetime callback')
+        self.session.add(user_2)
+        self.session.commit()
+
+    def tearDown(self):
+        Base.metadata.drop_all(self.engine)
+
+    def test_timestamp_must_be_abstract(self):
+        """Test whether TimestampMixin is abstract."""
+        self.assertTrue(hasattr(TimestampMixin, '__abstract__'),
+                        'TimestampMixin must have attribute __abstract__')
+        self.assertTrue(TimestampMixin.__abstract__,
+                        '__abstract__ must be True')
+
+    def test_timestamp_has_datetime_columns(self):
+        """Test whether TimestampMixin has attrs created_at and updated_at."""
+        user = self.session.query(User).first()
+
+        self.assertTrue(hasattr(User, 'created_at'),
+                        'Timestamp doesn\'t have created_at attribute.')
+        self.assertEqual(datetime, type(user.created_at),
+                         'created_at column should be datetime')
+
+        self.assertTrue(hasattr(User, 'updated_at'),
+                        'Timestamp doesn\'t have updated_at attribute.')
+        self.assertEqual(datetime, type(user.updated_at),
+                         'updated_at column should be datetime')
+
+    def test_updated_at_column_must_change_value(self):
+        """Test whether updated_at value is most recently after update."""
+        user = self.session.query(User).first()
+        dt_1 = user.updated_at
+
+        user.name = 'New name'
+        self.session.commit()
+
+        dt_2 = user.updated_at
+
+        self.assertLess(dt_1, dt_2, 'dt_1 should be older than dt_2')
+
+    def test_datetime_callback_could_be_customized(self):
+        """Test whether __datetime_callback__ is customized."""
+        expected = 'now'
+        result = UserCustomDatimeCallback.__datetime_callback__.__name__
+
+        self.assertNotEqual(TimestampMixin.__datetime_callback__.__name__,
+                            result)
+        self.assertEqual(expected, result,
+                         '__datetime_callback__ was\'t custom')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sqlalchemy_mixins/timestamp.py
+++ b/sqlalchemy_mixins/timestamp.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+import sqlalchemy as sa
+
+
+class TimestampMixin:
+    """Mixin that define timestamp columns."""
+
+    __abstract__ = True
+
+    __created_at_name__ = 'created_at'
+    __updated_at_name__ = 'updated_at'
+    __datetime_callback__ = datetime.utcnow
+
+    created_at = sa.Column(__created_at_name__,
+                           sa.DateTime,
+                           default=__datetime_callback__(),
+                           nullable=False)
+
+    updated_at = sa.Column(__updated_at_name__,
+                           sa.DateTime,
+                           default=__datetime_callback__(),
+                           nullable=False)
+
+
+@sa.event.listens_for(TimestampMixin, 'before_update', propagate=True)
+def _receive_before_update(mapper, connection, target):
+    """Listen for updates and update `updated_at` column."""
+    target.updated_at = target.__datetime_callback__()

--- a/sqlalchemy_mixins/timestamp.py
+++ b/sqlalchemy_mixins/timestamp.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import sqlalchemy as sa
 
 
-class TimestampMixin:
+class TimestampsMixin:
     """Mixin that define timestamp columns."""
 
     __abstract__ = True
@@ -23,7 +23,7 @@ class TimestampMixin:
                            nullable=False)
 
 
-@sa.event.listens_for(TimestampMixin, 'before_update', propagate=True)
+@sa.event.listens_for(TimestampsMixin, 'before_update', propagate=True)
 def _receive_before_update(mapper, connection, target):
     """Listen for updates and update `updated_at` column."""
     target.updated_at = target.__datetime_callback__()

--- a/sqlalchemy_mixins/timestamp.py
+++ b/sqlalchemy_mixins/timestamp.py
@@ -14,12 +14,12 @@ class TimestampMixin:
 
     created_at = sa.Column(__created_at_name__,
                            sa.DateTime,
-                           default=__datetime_callback__(),
+                           default=__datetime_callback__,
                            nullable=False)
 
     updated_at = sa.Column(__updated_at_name__,
                            sa.DateTime,
-                           default=__datetime_callback__(),
+                           default=__datetime_callback__,
                            nullable=False)
 
 


### PR DESCRIPTION
#8 Adds TimestampMixin support with attributes `created_at` and `updated_at`.

There is the possibility to change columns name, overriding `__created_at_name__` and `__updated_at_name`. 
Also have the capability to change the default datetime function, overriding the `__datetime_callback__` attribute.

I'll add examples with this both behaviors.