### PR TITLE
Serialize inherits inspection

### DIFF
--- a/sqlalchemy_mixins/serialize.py
+++ b/sqlalchemy_mixins/serialize.py
@@ -1,8 +1,12 @@
 from collections import Iterable
 
+from .inspection import InspectionMixin
 
-class SerializeMixin:
+
+class SerializeMixin(InspectionMixin):
     """Mixin to make model serializable."""
+
+    __abstract__ = True
 
     def to_dict(self, nested=False):
         """Return dict object with model's data.
@@ -12,11 +16,11 @@ class SerializeMixin:
         :return: dict
         """
         result = dict()
-        for key in self.__mapper__.c.keys():
+        for key in self.columns:
             result[key] = getattr(self, key)
 
         if nested:
-            for key in self.__mapper__.relationships.keys():
+            for key in self.relations:
                 obj = getattr(self, key)
 
                 if isinstance(obj, SerializeMixin):

--- a/sqlalchemy_mixins/tests/test_serialize.py
+++ b/sqlalchemy_mixins/tests/test_serialize.py
@@ -65,8 +65,6 @@ class TestSerialize(unittest.TestCase):
         self.session.add(user_2)
         self.session.commit()
 
-        self.session.commit()
-
         post_11 = Post(
             id=11,
             body='Post 11 body.',


### PR DESCRIPTION
This PR:
- Makes SerializeMixin an InspectionMixin subclass 
- Removes a unnecessary session.commit in tests