### PR TITLE
python 3.7 compatibility and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 # command to install dependencies
 install: "pip install -r requirements-dev.txt"
 # command to run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sqlalchemy >= 1.0
 six
-typing
+typing; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='sqlalchemy_mixins',
       install_requires=[
           "SQLAlchemy >= 1.0",
           "six",
-          "typing"
+          "typing; python_version < '3.5'"
       ],
       keywords=['sqlalchemy', 'active record', 'activerecord', 'orm',
                 'django-like', 'django', 'eager load', 'eagerload',  'repr',


### PR DESCRIPTION
Updated travis build to test against python 3.7 and made typing install necessary for only < python 3.5. (It was added to the standard library in 3.5 and causes import conflicts if installed via pip)