### PR TITLE
Add ability to use date comparison operators

### DIFF
--- a/examples/smartquery.py
+++ b/examples/smartquery.py
@@ -294,6 +294,8 @@ log(Comment.where(created_at__day=20).all())  # cm12, cm22
 # whole date
 log(Comment.where(created_at__year=2014, created_at__month=1,
                   created_at__day=1).all())  # cm11
+# date comparisons
+log(Comment.where(created_at__year_gt=2014).all())  # cm12, cm21, cm22
 
 ##### 1.4 where() with auto-joined relations #####
 

--- a/sqlalchemy_mixins/smartquery.py
+++ b/sqlalchemy_mixins/smartquery.py
@@ -159,8 +159,22 @@ class SmartQueryMixin(InspectionMixin, EagerLoadMixin):
         'iendswith': lambda c, v: c.ilike('%' + v),
 
         'year': lambda c, v: extract('year', c) == v,
+        'year_gt': lambda c, v: extract('year', c) > v,
+        'year_ge': lambda c, v: extract('year', c) >= v,
+        'year_lt': lambda c, v: extract('year', c) < v,
+        'year_le': lambda c, v: extract('year', c) <= v,
+
         'month': lambda c, v: extract('month', c) == v,
-        'day': lambda c, v: extract('day', c) == v
+        'month_gt': lambda c, v: extract('month', c) > v,
+        'month_ge': lambda c, v: extract('month', c) >= v,
+        'month_lt': lambda c, v: extract('month', c) < v,
+        'month_le': lambda c, v: extract('month', c) <= v,
+
+        'day': lambda c, v: extract('day', c) == v,
+        'day_gt': lambda c, v: extract('day', c) > v,
+        'day_ge': lambda c, v: extract('day', c) >= v,
+        'day_lt': lambda c, v: extract('day', c) < v,
+        'day_le': lambda c, v: extract('day', c) <= v,
     }
 
     @classproperty

--- a/sqlalchemy_mixins/smartquery.py
+++ b/sqlalchemy_mixins/smartquery.py
@@ -159,18 +159,21 @@ class SmartQueryMixin(InspectionMixin, EagerLoadMixin):
         'iendswith': lambda c, v: c.ilike('%' + v),
 
         'year': lambda c, v: extract('year', c) == v,
+        'year_ne': lambda c, v: extract('year', c) != v,
         'year_gt': lambda c, v: extract('year', c) > v,
         'year_ge': lambda c, v: extract('year', c) >= v,
         'year_lt': lambda c, v: extract('year', c) < v,
         'year_le': lambda c, v: extract('year', c) <= v,
 
         'month': lambda c, v: extract('month', c) == v,
+        'month_ne': lambda c, v: extract('month', c) != v,
         'month_gt': lambda c, v: extract('month', c) > v,
         'month_ge': lambda c, v: extract('month', c) >= v,
         'month_lt': lambda c, v: extract('month', c) < v,
         'month_le': lambda c, v: extract('month', c) <= v,
 
         'day': lambda c, v: extract('day', c) == v,
+        'day_ne': lambda c, v: extract('day', c) != v,
         'day_gt': lambda c, v: extract('day', c) > v,
         'day_ge': lambda c, v: extract('day', c) >= v,
         'day_lt': lambda c, v: extract('day', c) < v,

--- a/sqlalchemy_mixins/tests/test_smartquery.py
+++ b/sqlalchemy_mixins/tests/test_smartquery.py
@@ -368,6 +368,13 @@ class TestFilterExpr(BaseTest):
                   created_at__day=1), {cm11})
         test(dict(created_at=datetime.datetime(2014, 1, 1)), {cm11})
 
+        # date comparisons
+        test(dict(created_at__year_ge=2014), {cm11, cm12, cm21, cm22})
+        test(dict(created_at__year_gt=2014), {cm12, cm21, cm22})
+        test(dict(created_at__year_le=2015), {cm11, cm12, cm21})
+        test(dict(created_at__month_lt=10), {cm11})
+
+
 
 # noinspection PyUnusedLocal
 class TestOrderExpr(BaseTest):


### PR DESCRIPTION
I think ideally the syntax would be `{field}__day__lt`, but it doesn't seem like the current query mixin allows for this kind of syntax. 