### PR TITLE
fix error for queries with joins

### DIFF
--- a/sqlalchemy_mixins/smartquery.py
+++ b/sqlalchemy_mixins/smartquery.py
@@ -84,7 +84,7 @@ def smart_query(query, filters=None, sort_attrs=None, schema=None):
         schema = {}
 
     # noinspection PyProtectedMember
-    root_cls = query._joinpoint_zero().class_  # for example, User or Post
+    root_cls = query._entity_zero().class_  # for example, User or Post
     attrs = list(filters.keys()) + \
         list(map(lambda s: s.lstrip(DESC_PREFIX), sort_attrs))
     aliases = OrderedDict({})


### PR DESCRIPTION
Using `smart_query(query=SomeModel.join(OtherModel))` produces an error:
```
AttributeError: type object 'OtherModel' has no attribute 'class_'
```

closes #31 