### PR TITLE
Exception safe crud functions

### DIFF
--- a/sqlalchemy_mixins/__init__.py
+++ b/sqlalchemy_mixins/__init__.py
@@ -10,6 +10,8 @@ from .repr import ReprMixin
 from .serialize import SerializeMixin
 from .timestamp import TimestampsMixin
 
+# exception
+from .dbexception import DBException
 
 # all features combined to one mixin
 class AllFeaturesMixin(ActiveRecordMixin, SmartQueryMixin, ReprMixin, SerializeMixin):

--- a/sqlalchemy_mixins/activerecord.py
+++ b/sqlalchemy_mixins/activerecord.py
@@ -6,6 +6,9 @@ from .dbexception import DBException
 class ModelNotFoundError(ValueError):
     pass
 
+from sqlalchemy.exc import IntegrityError
+   
+
 class ActiveRecordMixin(InspectionMixin, SessionMixin):
     __abstract__ = True
 
@@ -26,7 +29,6 @@ class ActiveRecordMixin(InspectionMixin, SessionMixin):
         """
         Saves the updated model to the current entity db.
         """
-
         try:
             self.session.add(self)
             self.session.flush()
@@ -37,22 +39,26 @@ class ActiveRecordMixin(InspectionMixin, SessionMixin):
             raise DBException(name="Insertion Error", cause=str(e))
         return self
 
-
     @classmethod
     def create(cls, **kwargs):
-        """Create and persist a new record for the model
-        :param kwargs: attributes for the record
-        :return: the new model instance
+
+        """
+        Create and persist a new record for the model
+
+        :param kwargs: 
+            attributes for the record
+        :return: 
+            the new model instance
         """
         
-        return cls().fill(**kwargs).save()
+        return cls().fill(**kwargs)
   
 
     def update(self, **kwargs):
         """Same as :meth:`fill` method but persists changes to database.
         """
     
-        return self.fill(**kwargs).save()
+        return self.fill(**kwargs)
         
 
 

--- a/sqlalchemy_mixins/dbexception.py
+++ b/sqlalchemy_mixins/dbexception.py
@@ -1,0 +1,14 @@
+from sqlalchemy.exc import IntegrityError
+
+class DBException(Exception):
+    
+    """
+    custom exception class to handle sqlalchemy IntegrityError
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause.split(' ')[0]
+
+    def __str__(self):
+        return f"<name: {self.name}, cause: {self.cause}>"


### PR DESCRIPTION
Hi. I noticed that the mixins don't work well when the database throws an exception on things such as constraint violation. I've created a custom Exception class that handles the sqlalchemy IntegrityError and used it in the crud functions.
I've made save() a separately callable function instead of merging it with the crud functions since that way the ambiguity between autocommit true/false is resolved.

I'd appreciate it if you could go through the changes. :)