### PR TITLE
added functionality to exclude columns after serialzation from to dict

### DIFF
--- a/examples/serialize.py
+++ b/examples/serialize.py
@@ -18,9 +18,6 @@ class BaseModel(Base, SerializeMixin):
 
 class User(BaseModel):
     __tablename__ = 'user'
-    __exclude__ = [
-        'password'
-    ]
     id = sa.Column(sa.Integer, primary_key=True)
     password = sa.Column(sa.String)
     name = sa.Column(sa.String)
@@ -49,17 +46,17 @@ post2 = Post(body='Post 2', user=bob)
 session.add(post2)
 session.flush()
 
-# {'id': 1, 'name': 'Bob'}
+# {'id': 1, 'name': 'Bob' , 'password' : 'pass123'}
 print(bob.to_dict())
 
 # {'id': 1,
 # 'name': 'Bob',
 # 'posts': [{'body': 'Post 1', 'id': 1, 'user_id': 1},
 #           {'body': 'Post 2', 'id': 2, 'user_id': 1}]}
-print(bob.to_dict(nested=True))
+print(bob.to_dict(nested=True , exclude = ['password']))
 
 # {'id': 1, 'body': 'Post 1', 'user_id': 1}
 print(post1.to_dict())
 
-# {'id': 2, 'body': 'Post 2', 'user_id': 1, 'user': {'id': 1, 'name': 'Bob'}}
+# {'id': 2, 'body': 'Post 2', 'user_id': 1, 'user': {'id': 1, 'name': 'Bob' , 'password' : 'pass123'}}
 print(post2.to_dict(nested=True))

--- a/examples/serialize.py
+++ b/examples/serialize.py
@@ -18,8 +18,11 @@ class BaseModel(Base, SerializeMixin):
 
 class User(BaseModel):
     __tablename__ = 'user'
-
+    __exclude__ = [
+        'password'
+    ]
     id = sa.Column(sa.Integer, primary_key=True)
+    password = sa.Column(sa.String)
     name = sa.Column(sa.String)
     posts = sa.orm.relationship('Post', backref='user')
 
@@ -34,7 +37,7 @@ class Post(BaseModel):
 
 Base.metadata.create_all(engine)
 
-bob = User(name='Bob')
+bob = User(name='Bob' , password = "pass123")
 session.add(bob)
 session.flush()
 

--- a/sqlalchemy_mixins/serialize.py
+++ b/sqlalchemy_mixins/serialize.py
@@ -8,7 +8,7 @@ class SerializeMixin(InspectionMixin):
 
     __abstract__ = True
 
-    def to_dict(self, nested=False, hybrid_attributes=False):
+    def to_dict(self,nested =False, hybrid_attributes=False, exclude = []):
         """Return dict object with model's data.
 
         :param nested: flag to return nested relationships' data if true
@@ -17,9 +17,9 @@ class SerializeMixin(InspectionMixin):
         :return: dict
         """
         result = dict()
-        if hasattr(self , '__exclude__'):
-             view_cols = filter(lambda elem : elem not in self.__exclude__ ,
-                                self.columns)
+
+        if len(exclude) != 0 :
+             view_cols = filter(lambda e: e not in exclude, self.columns)
         else :
              view_cols = self.columns
 

--- a/sqlalchemy_mixins/serialize.py
+++ b/sqlalchemy_mixins/serialize.py
@@ -8,7 +8,7 @@ class SerializeMixin(InspectionMixin):
 
     __abstract__ = True
 
-    def to_dict(self,nested =False, hybrid_attributes=False, exclude = []):
+    def to_dict(self,nested = False, hybrid_attributes = False, exclude = None):
         """Return dict object with model's data.
 
         :param nested: flag to return nested relationships' data if true
@@ -18,10 +18,10 @@ class SerializeMixin(InspectionMixin):
         """
         result = dict()
 
-        if len(exclude) != 0 :
-             view_cols = filter(lambda e: e not in exclude, self.columns)
-        else :
+        if exclude is None:
              view_cols = self.columns
+        else :
+             view_cols = filter(lambda e: e not in exclude, self.columns)
 
         for key in view_cols :
             result[key] = getattr(self, key)

--- a/sqlalchemy_mixins/serialize.py
+++ b/sqlalchemy_mixins/serialize.py
@@ -17,7 +17,13 @@ class SerializeMixin(InspectionMixin):
         :return: dict
         """
         result = dict()
-        for key in self.columns:
+        if hasattr(self , '__exclude__'):
+             view_cols = filter(lambda elem : elem not in self.__exclude__ ,
+                                self.columns)
+        else :
+             view_cols = self.columns
+
+        for key in view_cols :
             result[key] = getattr(self, key)
 
         if hybrid_attributes:

--- a/sqlalchemy_mixins/serialize.pyi
+++ b/sqlalchemy_mixins/serialize.pyi
@@ -1,6 +1,6 @@
 from sqlalchemy_mixins.inspection import InspectionMixin
-
+from typing import Optional , List
 
 class SerializeMixin(InspectionMixin):
 
-    def to_dict(self, nested: bool = False, hybrid_attributes: bool = False) -> dict: ...
+    def to_dict(self, nested: bool = False, hybrid_attributes: bool = False, exclude: Optional[List[str]] = None) -> dict: ...

--- a/sqlalchemy_mixins/tests/test_serialize.py
+++ b/sqlalchemy_mixins/tests/test_serialize.py
@@ -22,6 +22,7 @@ class User(BaseModel):
     id = sa.Column(sa.Integer, primary_key=True)
     name = sa.Column(sa.String)
     posts = sa.orm.relationship('Post')
+    password = sa.Column(sa.String)
 
     @hybrid_property
     def posts_count(self):
@@ -62,11 +63,11 @@ class TestSerialize(unittest.TestCase):
         self.session = Session(self.engine)
         Base.metadata.create_all(self.engine)
 
-        user_1 = User(name='Bill u1', id=1)
+        user_1 = User(name='Bill u1', id=1 , password = 'pass1')
         self.session.add(user_1)
         self.session.commit()
 
-        user_2 = User(name='Alex u2', id=2)
+        user_2 = User(name='Alex u2', id=2 , password = 'pass2')
         self.session.add(user_2)
         self.session.commit()
 
@@ -93,7 +94,9 @@ class TestSerialize(unittest.TestCase):
         Base.metadata.drop_all(self.engine)
 
     def test_serialize_single(self):
-        result = self.session.query(User).first().to_dict()
+        result = self.session.query(User)\
+                    .first()\
+                    .to_dict(exclude= ['password'])
         expected = {
             'id': 1,
             'name': 'Bill u1'
@@ -101,7 +104,7 @@ class TestSerialize(unittest.TestCase):
         self.assertDictEqual(result, expected)
 
     def test_serialize_list(self):
-        result = [user.to_dict() for user in self.session.query(User).all()]
+        result = [user.to_dict(exclude = ['password']) for user in self.session.query(User).all()]
         expected = [
             {
                 'id': 1,
@@ -124,7 +127,8 @@ class TestSerialize(unittest.TestCase):
             'user_id': 1,
             'user': {
                 'id': 1,
-                'name': 'Bill u1'
+                'name': 'Bill u1' ,
+                'password' : 'pass1'
             },
             'comments': [
                 {
@@ -139,7 +143,9 @@ class TestSerialize(unittest.TestCase):
         self.assertDictEqual(result, expected)
 
     def test_serialize_single__with_hybrid(self):
-        result = self.session.query(User).first().to_dict(hybrid_attributes=True)
+        result = self.session.query(User)\
+                    .first()\
+                    .to_dict(hybrid_attributes=True , exclude = ['password'])
         expected = {
             'id': 1,
             'name': 'Bill u1',
@@ -157,7 +163,8 @@ class TestSerialize(unittest.TestCase):
             'user': {
                 'id': 1,
                 'name': 'Bill u1',
-                'posts_count': 1
+                'posts_count': 1 ,
+                'password' : 'pass1'
             },
             'comments': [
                 {


### PR DESCRIPTION
columns can be added in __exclude__ list in the models and when we call to to_dict from the serializer mixin it filters out  those columns 