### PR TITLE
Legacy API Fix

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 nose2
 coverage
 codeclimate-test-reporter
+greenlet>=3.1
 tox
 mypy==1.1.1
 sqlalchemy[mypy] >= 2.0

--- a/sqlalchemy_mixins/activerecord.py
+++ b/sqlalchemy_mixins/activerecord.py
@@ -77,18 +77,18 @@ class ActiveRecordMixin(InspectionMixin, SessionMixin):
 
     @classmethod
     def all(cls):
-        return cls.query.all()
+        return cls.session.query(cls).all()
 
     @classmethod
     def first(cls):
-        return cls.query.first()
+        return cls.session.query(cls).first()
 
     @classmethod
     def find(cls, id_):
         """Find record by the id
         :param id_: the primary key
         """
-        return cls.query.get(id_)
+        return cls.session.query(cls).get(id_)
 
     @classmethod
     def find_or_fail(cls, id_):


### PR DESCRIPTION
I received the following Legacy API Warning:

/.venv/lib/python3.12/site-packages/sqlalchemy_mixins/activerecord.py:91: LegacyAPIWarning: The Query.get() method is considered legacy as of the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0. The method is now available as Session.get() (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

This patch updates the SQLAlchemy 1.x style Class.query calls to use SQLAlchemy 2.0 style
Session.Query style calls.  This removes the warning for me.

I have ran the test suite and all tests pass.  I also noticed that greenlet was not included in the requirements-dev.txt file, so I have also included a commit to add it.
